### PR TITLE
I've removed the 'voxtral' model from the list of available transcrip…

### DIFF
--- a/src/components/ModelSelectorComponent.tsx
+++ b/src/components/ModelSelectorComponent.tsx
@@ -37,9 +37,6 @@ const ModelSelectorComponent: React.FC<ModelSelectorComponentProps> = ({
           <option value="small.en">🇺🇸 Small English ({whisperModels['small.en'].size})</option>
           <option value="small">🌍 Small Multilingual ({whisperModels['small'].size})</option>
         </optgroup>
-        <optgroup label="Advanced Models (Experimental)">
-          <option value="voxtral">🔊 Voxtral ({whisperModels['voxtral'].size})</option>
-        </optgroup>
       </select>
       <div className="model-info">
         <span className="model-stats">

--- a/src/hooks/useTranscription.ts
+++ b/src/hooks/useTranscription.ts
@@ -8,7 +8,6 @@ export const WHISPER_MODELS = {
   'base.en': { id: 'Xenova/whisper-base.en', name: 'Base English (74MB)', size: '74MB', speed: 'Fast', accuracy: 'Good' },
   'small': { id: 'Xenova/whisper-small', name: 'Small (244MB)', size: '244MB', speed: 'Medium', accuracy: 'Better' },
   'small.en': { id: 'Xenova/whisper-small.en', name: 'Small English (244MB)', size: '244MB', speed: 'Medium', accuracy: 'Better' },
-  'voxtral': { id: 'mistralai/Voxtral-Mini-3B-2507', name: 'Voxtral Mini (3B)', size: '3GB', speed: 'Slow', accuracy: 'Best' },
 } as const;
 
 export type WhisperModelKey = keyof typeof WHISPER_MODELS;


### PR DESCRIPTION
…tion models.

I found that this model ('mistralai/Voxtral-Mini-3B-2507') is for text generation, not speech recognition. Attempting to use it for transcription was causing an 'Unsupported model type: whisper' error from the underlying transformers library.

To prevent this from happening, I removed the incompatible model from both the model list in `useTranscription.ts` and the UI in `ModelSelectorComponent.tsx`.